### PR TITLE
Tune configs need for releasing

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,6 @@
 engines:
   standard:
     enabled: true
-    channel: latest
+    channel: beta
 exclude_paths:
 - spec/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --update build-base && \
     gem install bundler && \
     bundle install --quiet -j 4 --without=test && \
     chown -R app:app /usr/local/bundle && \
-    rm -fr ~/.gem ~/.bundle ~/.wh..gem && \
+    rm -fr ~/.gem ~/.bundle && \
     apk del build-base
 
 COPY . /usr/src/app


### PR DESCRIPTION
- Pointing at  `beta`  so we can use this repo to test itself. `beta` is the first channel we push up and we can use for upgrades before updating `stable`.

- Circle is also having some trouble building the image, the change is an attempt to fix it, and doesn't seem to have a greater impact overall